### PR TITLE
Additional instructions for Windows + changed CMakeLists.txt

### DIFF
--- a/coro-fibs/CMakeLists.txt
+++ b/coro-fibs/CMakeLists.txt
@@ -4,9 +4,19 @@ add_executable(${TNAME} corofibs.cc sumfib_module.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
 
+if (WIN32)
+# cannot use cmd here because of some strange things in path: https://gitlab.kitware.com/cmake/cmake/-/issues/17067
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})

--- a/excret/CMakeLists.txt
+++ b/excret/CMakeLists.txt
@@ -6,11 +6,21 @@ add_executable(${TNAME} exc_ret_1.cc exc_ret_2.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 # same benchmark, version when no exception happened
 
@@ -21,8 +31,18 @@ target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 target_compile_definitions(${TNAME} PUBLIC NOEXC)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+

--- a/inline/CMakeLists.txt
+++ b/inline/CMakeLists.txt
@@ -4,9 +4,18 @@ add_executable(${TNAME} extswap.cc  partition.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
 

--- a/noexcept-qsort/CMakeLists.txt
+++ b/noexcept-qsort/CMakeLists.txt
@@ -4,11 +4,21 @@ add_executable(${TNAME} exc_qsort.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 SET(TNAME exc_partition)
 
@@ -16,10 +26,20 @@ add_executable(${TNAME} exc_partition.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 

--- a/ranges-filter/CMakeLists.txt
+++ b/ranges-filter/CMakeLists.txt
@@ -4,10 +4,20 @@ add_executable(${TNAME} filter.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 

--- a/ranges-projector/CMakeLists.txt
+++ b/ranges-projector/CMakeLists.txt
@@ -4,10 +4,20 @@ add_executable(${TNAME} projector.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 

--- a/readme.md
+++ b/readme.md
@@ -31,14 +31,29 @@ If you have custom compiler be sure it is inside profile.
 
 Now you are ready for main build and run. Conan will download all dependencies for you.
 
-```
+## Linux build
+
+```bash
 conan install conanfile.txt --build=missing
 cmake -S . -B build/Release --toolchain build/Release/generators/conan_toolchain.cmake  -DCMAKE_BUILD_TYPE=Release
 cmake --build build/Release
 env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build/Release --target test --parallel 1
 ```
 
-This will take some time, be patient. Benchmarking results will be created in the build/Release/CSVS folder. 
+## Windows build
+
+It is highly recommended to use developer powershell
+
+```pwsh
+conan install conanfile.txt --build=missing
+cmake -S . -B .\build --toolchain .\build\generators\conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+cmake --build --preset conan-release
+powershell -command { $env:CTEST_OUTPUT_ON_FAILURE='1'; cmake --build --preset conan-release --target RUN_TESTS --parallel 1 }
+```
+
+---
+
+This will take some time, be patient. Benchmarking results will be created in the build/Release/CSVS folder for Linux and in build/CSVS folder for Windows. 
 
 You are welcome to create MR in results folder with your architecture and name it will help my talk!
 

--- a/virtual-inherit/CMakeLists.txt
+++ b/virtual-inherit/CMakeLists.txt
@@ -4,10 +4,20 @@ add_executable(${TNAME} virtinh.cc fmodule.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
 
 

--- a/virtual-inline/CMakeLists.txt
+++ b/virtual-inline/CMakeLists.txt
@@ -4,10 +4,20 @@ add_executable(${TNAME} virtinl.cc fmodule.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
 
 

--- a/virtual-inline/virtinl.cc
+++ b/virtual-inline/virtinl.cc
@@ -14,6 +14,12 @@
 #include "benchmark/cppbenchmark.h"
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+#define NOINLINE __declspec(noinline)
+#else
+#define NOINLINE __attribute__((noinline))
+#endif
+
 constexpr int NCALL = 100;
 constexpr int NBMK = 10000;
 
@@ -49,14 +55,14 @@ struct VirtDerived : VirtBase {
   }
 };
 
-int __attribute__((noinline)) startup(NonVirt *nv) {
+NOINLINE int startup(NonVirt *nv) {
   int sum = 0;
   for (int i = 0; i < NBMK; ++i)
     sum += nv->bar(NCALL);
   return sum;
 }
 
-int __attribute__((noinline)) startup(VirtBase *vb) {
+NOINLINE int startup(VirtBase *vb) {
   int sum = 0;
   for (int i = 0; i < NBMK; ++i)
     sum += vb->bar(NCALL);

--- a/virtual-overhead/CMakeLists.txt
+++ b/virtual-overhead/CMakeLists.txt
@@ -4,11 +4,22 @@ add_executable(${TNAME} virtual-1.cc virtual-2.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 SET(TNAME virtual-shuffle)
 
@@ -16,10 +27,21 @@ add_executable(${TNAME} virtual-shuffle-1.cc virtual-shuffle-2.cc)
 target_compile_features(${TNAME} PRIVATE cxx_std_20)
 target_link_libraries(${TNAME} cppbenchmark::cppbenchmark)
 
-add_test(
-  NAME TEST_${TNAME}
-  COMMAND sh -c "./${TNAME} -q -o csv > ${CSVS}/${TNAME}.csv"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+file(TO_NATIVE_PATH "${CSVS}/${TNAME}.csv" CSV_OUT)
+
+if (WIN32)
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND powershell -command "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}" 
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+else()
+  add_test(
+    NAME TEST_${TNAME}
+    COMMAND sh -c "$<TARGET_FILE:${TNAME}> -q -o csv > ${CSV_OUT}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 set_tests_properties(${TEST_TARGET} PROPERTIES DEPENDS ${TNAME})
+
 
 


### PR DESCRIPTION
Added:
 - Windows build instructions into `readme.md`

Changed:
 - now `CMakeLists.txt` for every benchmark will generate right test for Windows.

About Windows build:
Sadly, original command `cmake --build build/Release` just won't work at all. Every time when I try to use it, msvc cannot find `cppbenchmark` headers. Why? I still do not fully understand. But the combination of "not creating additional folder for release build" and running `cmake --build --preset conan-release` gives an expected result. 

Sadly, `--preset` requires CMake 3.19, and I cannot find any information about which version of VS build tools provides which version of CMake to write it down into `readme.md`

P.S. I am not quite sure about black magic inside `add_test` and my `NOINLINE` macro. As per my tests, they work on msvc and gcc as expected